### PR TITLE
Fix duplicate xmlns props in SVG components to resolve lint errors

### DIFF
--- a/src/containers/skills/CloudInfraImg.js
+++ b/src/containers/skills/CloudInfraImg.js
@@ -10,7 +10,7 @@ export default function CloudInfraImg(props) {
       preserveAspectRatio="none"
       version="1.1"
       id="svg675"
-      xmlns="http://www.w3.org/1999/xlink"
+      xmlnsXlink="http://www.w3.org/1999/xlink"
       xmlns="http://www.w3.org/2000/svg"
     >
       <defs id="defs679" />

--- a/src/containers/skills/FullStackImg.js
+++ b/src/containers/skills/FullStackImg.js
@@ -10,7 +10,6 @@ export default function FullStackImg(props) {
       viewBox="0 0 1076.06371 755.2279"
       version="1.1"
       xmlns="http://www.w3.org/2000/svg"
-      xmlns="http://www.w3.org/2000/svg"
     >
       <defs id="defs93" />
       <path

--- a/src/pages/experience/ExperienceImg.js
+++ b/src/pages/experience/ExperienceImg.js
@@ -11,7 +11,6 @@ export default function ExperienceImg(props) {
       viewBox="0 0 1094 760"
       version="1.1"
       xmlns="http://www.w3.org/2000/svg"
-      xmlns="http://www.w3.org/2000/svg"
     >
       <defs id="defs123" />
       <title id="title2" />


### PR DESCRIPTION
Removed duplicate xmlns prop in FullStackImg.js and ExperienceImg.js,
and changed the duplicate xmlns to xmlnsXlink in CloudInfraImg.js
(which had both xlink and svg namespace URIs).

https://claude.ai/code/session_019cUfGqoRpFr1whmQPkBXxh