### PR TITLE
Fix deployment: add automatic gh-pages deploy to CI workflow

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,7 +1,4 @@
-# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
-
-name: Node.js CI
+name: Build and Deploy
 
 on:
   push:
@@ -10,32 +7,31 @@ on:
     branches: [ main ]
 
 jobs:
-  build:
-
+  build-and-deploy:
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        node-version: [12.x]
-        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
-
     steps:
-    - uses: actions/checkout@v2
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+    - uses: actions/checkout@v4
+
+    - name: Use Node.js 18
+      uses: actions/setup-node@v4
       with:
-        node-version: ${{ matrix.node-version }}
+        node-version: 18
+        cache: npm
+
     - run: npm ci
-      env: 
+      env:
         CI: ""
-    - run: npm run build --if-present
+
+    - run: npm run build
+
     - run: npm test
-    
-#     - name: Deploy to netlify
-#       uses: netlify/actions/cli@master
-#       env:
-#         NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
-#         NETLIFY_SITE_ID: ${{ secrets.DEV_NETLIFY_SITE_ID }}
-#       with:
-#         args: deploy --dir=build --prod
-#         secrets: '["NETLIFY_AUTH_TOKEN", "NETLIFY_SITE_ID"]'
+      env:
+        CI: "true"
+
+    - name: Deploy to GitHub Pages
+      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+      uses: peaceiris/actions-gh-pages@v4
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./build


### PR DESCRIPTION
The deployed site was out of sync because the CI workflow only built and
tested but never deployed. The gh-pages branch hadn't been updated since
2023-09-12, while main had newer merged PRs.

Changes:
- Add peaceiris/actions-gh-pages deploy step that runs on push to main
- Upgrade from Node 12 (EOL) to Node 18
- Update actions/checkout and actions/setup-node to v4

https://claude.ai/code/session_01ABNRRpFJN8dmYagfC1ES4Z